### PR TITLE
Do not check if the init is a binary file.

### DIFF
--- a/Linux/tree-armv7l/init
+++ b/Linux/tree-armv7l/init
@@ -167,15 +167,12 @@ mount -o move /dev ${rootmnt}/dev
 mv /initramfs ${rootmnt}/run/initramfs
 
 
-# Check if $init exists and is executable
-if [[ -x "${rootmnt}/${init}" ]] ; then
-    # Unmount all other mounts so that the ram used by
-    # the initramfs can be cleared after switch_root
-    # umount /sys /proc
+# Unmount all other mounts so that the ram used by
+# the initramfs can be cleared after switch_root
+# umount /sys /proc
 
-    # Switch to the new root and execute init
-    exec switch_root "${rootmnt}" "${init}"
-fi
+# Switch to the new root and execute init
+exec switch_root "${rootmnt}" "${init}"
 
 
 # This will only be run if the exec above failed


### PR DESCRIPTION
If the init is symlinked to an absolute path (systemd on some
distributions -> /lib/systemd/systemd), the check fails because
/lib/systemd/systemd doesn't exists in the root of the initramfs.

It's not an issue to remove this extra check: if it fails because the
init isn't an executable, we'll still have the shell dropped.