### PR TITLE
Improved warn dropbear message

### DIFF
--- a/Linux/tree-armv7l/init
+++ b/Linux/tree-armv7l/init
@@ -199,12 +199,15 @@ if [ "$(get_any INITRD_DROPBEAR)" = "1" ]; then
 
     ewarn ""
     ewarn "**DEBUG DROPBEAR** (requested from the TAGS metadata of the server)"
-    ewarn "To continue the initrd process, just type 'continue-boot'"
     ewarn ""
-    ewarn "You can connect to your serveur using: 'scw exec $(oc-metadata --cached ID)'"
+    ewarn "To continue the initrd process:"
+    ewarn " -- You must run 'continue-boot' with a remote access"
+    ewarn ""
+    ewarn "You can connect to your server with 'scw' or 'ssh'"
+    ewarn " -- scw exec $(oc-metadata --cached ID)"
+    ewarn " -- ssh root@$(oc-metadata --cached PUBLIC_IP_ADDRESS)"
     ewarn ""
 
-    # FIXME: display ssh command and scw command
     # FIXME: display common usages (luks, lvm, etc) in a README.txt file
     run mkfifo /continue
     run cat /continue


### PR DESCRIPTION
before
```
>>>
>>> **DEBUG DROPBEAR** (requested from the TAGS metadata of the server)
>>> To continue the initrd process, just type 'continue-boot'
>>>
>>> You can connect to your serveur using: 'scw exec XXX-XXX-XXX-XXX-XXX'
>>>
```

after
```
>>>
>>> **DEBUG DROPBEAR** (requested from the TAGS metadata of the server)
>>>
>>> To continue the initrd process:
>>>  -- You must run 'continue-boot' with a remote access
>>>
>>> You can connect to your server with 'scw' or 'ssh'
>>>  -- scw exec XXX-XXX-XXX-XXX-XXX
>>>  -- ssh root@X.X.X.X
>>>
```