### PR TITLE
Fixed regression on booting servers with cmdline containing 'boot=local'

### DIFF
--- a/Linux/README.md
+++ b/Linux/README.md
@@ -62,9 +62,9 @@ Here are the availble *initrd variables*:
 
 ## Changelog
 
-### v3.5 (unreleased)
+### master (unreleased)
 
-* No entry
+* Fix: regression on booting servers with cmdline containing 'boot=local' [#97](https://github.com/scaleway/initrd/issues/97)
 
 ### v3.4 (2015-10-05)
 

--- a/Linux/tree-common/boot-local
+++ b/Linux/tree-common/boot-local
@@ -2,7 +2,13 @@
 
 
 mountroot() {
-    log_begin_msg "Mounting local disk: ${root}"
-    emount "${root}" "${rootmnt}"
-    log_end_msg
+    if [ "$root" = "/dev/nbd0" ]; then
+	attach_nbd_device 0
+	mount_nbd 0 "${rootmnt}"
+	attach_secondary_nbd_devices
+    else
+	log_begin_msg "Mounting local disk: ${root}"
+	emount "${root}" "${rootmnt}"
+	log_end_msg
+    fi
 }

--- a/Linux/tree-common/boot-nbd
+++ b/Linux/tree-common/boot-nbd
@@ -1,8 +1,0 @@
-# -*- shell-script -*-
-
-
-mountroot() {
-    attach_nbd_device 0
-    mount_nbd 0 "${rootmnt}"
-    attach_secondary_nbd_devices
-}


### PR DESCRIPTION
Fix #97