### PR TITLE
Use ntp.int.scaleway.com intead of ntp.int.cloud.online.net

### DIFF
--- a/Openbsd/tree-Openbsd-armv7/etc/ntpd.conf
+++ b/Openbsd/tree-Openbsd-armv7/etc/ntpd.conf
@@ -1,1 +1,1 @@
-servers ntp.int.cloud.online.net
+servers ntp.int.scaleway.com


### PR DESCRIPTION
See: https://github.com/scaleway/image-debian/issues/42