### PR TITLE
Btrfs support in boot=live

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,6 @@ export.tar
 minirootfs
 minirootfs.tar
 
+armdisk.img
+
 qemu/metadata_mock/static/

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -59,11 +59,22 @@ qemu:
 	$(MAKE) qemu-docker-text || $(MAKE) qemu-local-text
 
 
+armdisk.img:
+	qemu-img create -f raw armdisk.img 8G
+
 qemu-local-text:	vmlinuz initrd-Linux-$(TARGET).gz
 	qemu-system-arm \
 		$(QEMU_OPTIONS) \
 		-append "console=ttyAMA0 earlyprink=ttyAMA0 $(CMDLINE) INITRD_DEBUG=$(INITRD_DEBUG)" \
 		-kernel ./vmlinuz \
+		-initrd ./initrd-Linux-$(TARGET).gz \
+		-nographic -monitor null
+
+qemu-live-btrfs-text:	vmlinuz initrd-Linux-$(TARGET).gz armdisk.img
+	qemu-system-arm \
+		$(QEMU_OPTIONS) \
+		-append "console=ttyAMA0 earlyprink=ttyAMA0 ip=dhcp root=/dev/sda boot=live live_mkfs=btrfs nousb noplymouth INITRD_POST_SHELL=1" \
+		-kernel ./vmlinuz -drive file=armdisk.img,format=raw \
 		-initrd ./initrd-Linux-$(TARGET).gz \
 		-nographic -monitor null
 

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -13,6 +13,7 @@ DEPENDENCIES ?=	\
 	/lib/x86_64-linux-gnu/libnss_files.so.2 \
 	/lib/x86_64-linux-gnu/libresolv.so.2 \
 	/sbin/mkfs.ext4 \
+	/sbin/mkfs.btrfs \
 	/sbin/parted \
 	/usr/bin/dropbearkey \
 	/usr/lib/klibc/bin/ipconfig \

--- a/Linux/dependencies-armv7l/Dockerfile
+++ b/Linux/dependencies-armv7l/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
    nfs-common \
    ntpdate \
    parted \
+   btrfs-tools \
    udhcpc \
    wget \
  && apt-get clean

--- a/Linux/tree-common/boot-live
+++ b/Linux/tree-common/boot-live
@@ -9,6 +9,7 @@ live_install() {
 
     case "${filesystem}" in
         btrfs)
+            load_btrfs_ko
             run sh -ec "mkfs.btrfs -f -O ^extref,^skinny-metadata '${root}'" || log_fatal_msg "Cannot format root"
             ;;
         *)

--- a/Linux/tree-common/boot-live
+++ b/Linux/tree-common/boot-live
@@ -18,7 +18,7 @@ live_install() {
     esac
     log_end_msg
 
-    mount_nbd 0 "${rootmnt}"
+    test ${root} == /dev/nbd0 && mount_nbd 0 ${rootmnt} || mount ${root} ${rootmnt}
 
     log_begin_msg "Installing live image (${rescue_image})"
     run sh -ec "wget -qO- '${rescue_image}' | tar -C '${rootmnt}' -x -f -"
@@ -28,7 +28,7 @@ live_install() {
 
 
 mountroot() {
-    attach_nbd_device 0
+    test ${root} == /dev/nbd0 && attach_nbd_device 0
 
     live_mode=$(get_any live_mode "auto")
     rescue_image=$(get_any rescue_image)

--- a/Linux/tree-common/boot-live
+++ b/Linux/tree-common/boot-live
@@ -4,8 +4,18 @@
 live_install() {
     local rescue_image="${1}"
 
-    log_begin_msg "Formating nbd0"
-    run sh -ec 'mkfs.ext4 -F /dev/nbd0 || log_fatal_msg "Cannot format nbd0"'
+    filesystem=$(get_any live_mkfs "ext4")
+    log_begin_msg "Formating root:${root} with mkfs.${filesystem}"
+
+    case "${filesystem}" in
+        btrfs)
+            run sh -ec "mkfs.btrfs -f -O ^extref,^skinny-metadata '${root}'" || log_fatal_msg "Cannot format root"
+            ;;
+        *)
+            #default to ext4
+            run sh -ec "mkfs.ext4 -F '${root}'" || log_fatal_msg "Cannot format root"
+            ;;
+    esac
     log_end_msg
 
     mount_nbd 0 "${rootmnt}"

--- a/Linux/tree-common/functions
+++ b/Linux/tree-common/functions
@@ -187,19 +187,30 @@ get_any() {
 }
 
 
-load_nolp_ko() {
-    log_begin_msg "Loading nolp kernel module"
-    run wget -q http://169.254.42.24/kernel/$(uname -r)/custom/nolp.ko
-    run insmod $(pwd)/nolp.ko
+insmod_ko() {
+    mod_path=$1
+    log_begin_msg "Loading ${mod_path} kernel module"
+    run wget -q -O mod.ko http://169.254.42.24/kernel/$(uname -r)/kernel/${mod_path}
+    run insmod $(pwd)/mod.ko
     if [ $? -eq 0 ]; then
-        log_success_msg "nolp.ko successfully loaded"
+        log_success_msg "successfully loaded"
         log_end_msg
     else
-        log_warning_msg "cannot load nolp.ko"
+        log_warning_msg "cannot load module"
         log_end_msg
     fi
 }
 
+load_nolp_ko() {
+    insmod_ko custom/nolp.ko
+}
+
+load_btrfs_ko() {
+    insmod_ko crypto/xor.ko
+    insmod_ko lib/raid6/raid6_pq.ko
+    insmod_ko lib/zlib_deflate/zlib_deflate.ko
+    insmod_ko fs/btrfs/btrfs.ko
+}
 
 setup_gpios() {
     # Switch booted GPIO to enable serial for user


### PR DESCRIPTION
As discussed here : https://github.com/scaleway-community/scaleway-docker/pull/46
This patch would allow using btrfs on nbd0.
There might be more testing needed, the qemu kernel is not on the module repository, so I cannot insmod btrfs.ko & have no btrfs support in qemu.