### PR TITLE
Improve multiarch & cross-build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ minirootfs.tar
 armdisk.img
 
 qemu/metadata_mock/static/
+*/dependencies-*/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ before_install:
 #- if [ "$ACTION" = "build" -a -n "$TRAVIS_TAG" ]; then sudo apt-get update && sudo apt-get install -y u-boot-tools || true; fi
 
 script:
-- if [ "$ACTION" = "check" ]; then cd Linux && make           travis_check; fi
-- if [ "$ACTION" = "check" ]; then cd Openbsd && make         travis_check; fi
-- if [ "$ACTION" = "check" ]; then cd scw-boot-tools && make  travis_check; fi
-- if [ "$ACTION" = "build" ]; then cd Linux && make           travis_build; fi
-- if [ "$ACTION" = "build" ]; then cd Openbsd && make         travis_build; fi
-- if [ "$ACTION" = "build" ]; then cd scw-boot-tools && make  travis_build; fi
+- if [ "$ACTION" = "check" ]; then cd ${TRAVIS_BUILD_DIR}/Linux && make           travis_check; fi
+- if [ "$ACTION" = "check" ]; then cd ${TRAVIS_BUILD_DIR}/Openbsd && make         travis_check; fi
+- if [ "$ACTION" = "check" ]; then cd ${TRAVIS_BUILD_DIR}/scw-boot-tools && make  travis_check; fi
+- if [ "$ACTION" = "build" ]; then cd ${TRAVIS_BUILD_DIR}/Linux && make           travis_build; fi
+- if [ "$ACTION" = "build" ]; then cd ${TRAVIS_BUILD_DIR}/Openbsd && make         travis_build; fi
+- if [ "$ACTION" = "build" ]; then cd ${TRAVIS_BUILD_DIR}/scw-boot-tools && make  travis_build; fi
 - ls -laR

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
 sudo: required
 
 env:
-- ACTION=check
-- ACTION=build
+- ACTION=check  TARGET=x86_64
+- ACTION=build  TARGET=x86_64
 
 before_install:
 - env

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,10 @@ before_install:
 #- if [ "$ACTION" = "build" -a -n "$TRAVIS_TAG" ]; then sudo apt-get update && sudo apt-get install -y u-boot-tools || true; fi
 
 script:
-- if [ "$ACTION" = "check" ]; then make -C Linux          travis_check; fi
-- if [ "$ACTION" = "check" ]; then make -C Openbsd        travis_check; fi
-- if [ "$ACTION" = "check" ]; then make -C scw-boot-tools travis_check; fi
-- if [ "$ACTION" = "build" ]; then make -C Linux          travis_build; fi
-- if [ "$ACTION" = "build" ]; then make -C Openbsd        travis_build; fi
-- if [ "$ACTION" = "build" ]; then make -C scw-boot-tools travis_build; fi
+- if [ "$ACTION" = "check" ]; then cd Linux && make           travis_check; fi
+- if [ "$ACTION" = "check" ]; then cd Openbsd && make         travis_check; fi
+- if [ "$ACTION" = "check" ]; then cd scw-boot-tools && make  travis_check; fi
+- if [ "$ACTION" = "build" ]; then cd Linux && make           travis_build; fi
+- if [ "$ACTION" = "build" ]; then cd Openbsd && make         travis_build; fi
+- if [ "$ACTION" = "build" ]; then cd scw-boot-tools && make  travis_build; fi
 - ls -laR
-

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -302,3 +302,10 @@ metadata_mock/static/minirootfs.tar:	minirootfs.tar
 minirootfs.tar:	minirootfs
 	tar --format=gnu -C $< -cf $@.tmp . 2>/dev/null || tar --format=pax -C $< -cf $@.tmp . 2>/dev/null
 	mv $@.tmp $@
+
+
+clean:
+	rm -rf output-$(TARGET) dependencies-$(TARGET).tar.gz initrd-Linux-$(TARGET).gz uInitrd-Linux-$(TARGET)
+
+
+re: clean all

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -239,7 +239,19 @@ dependencies.tar.gz:	dependencies-$(TARGET).tar.gz
 
 
 dependencies-$(TARGET).tar.gz:	dependencies-$(TARGET)/Dockerfile
-	$(MAKE) dependencies-$(TARGET).tar.gz-armhf || $(MAKE) dependencies-$(TARGET).tar.gz-dist
+	test $(HOST_ARCH) = $(TARGET) || docker run --rm --privileged multiarch/qemu-user-static:register --reset
+
+	docker build -q -t $(DOCKER_DEPENDENCIES) ./dependencies-$(TARGET)/
+	docker run -it $(DOCKER_DEPENDENCIES) export-assets $(DEPENDENCIES)
+	docker cp `docker ps -lq`:/tmp/dependencies.tar $(PWD)/
+	mv dependencies.tar dependencies-$(TARGET).tar
+	(cd ../scw-boot-tools; tar -uf ../Linux/dependencies-$(TARGET).tar usr/bin/scw-update-server-state)
+	docker rm `docker ps -lq`
+	rm -f dependencies-$(TARGET).tar.gz
+	@ls -lah dependencies-$(TARGET).tar
+	gzip dependencies-$(TARGET).tar
+	@ls -lah dependencies-$(TARGET).tar.gz
+
 	tar tvzf $@ | grep bin/busybox || rm -f $@
 	@test -f $@ || echo $@ is broken
 	@test -f $@ || exit 1
@@ -256,24 +268,6 @@ dependencies-shell:
 	mkdir -p ../scw-boot-tools/usr/bin
 	cp ../scw-boot-tools/scw-update-server-state ../scw-boot-tools/usr/bin/
 	chmod +x ../scw-boot-tools/usr/bin/scw-update-server-state
-
-
-dependencies-$(TARGET).tar.gz-armhf: dependencies-$(TARGET) ../scw-boot-tools/usr/bin/scw-update-server-state
-	test $(HOST_ARCH) = $(TARGET)
-	docker build -q -t $(DOCKER_DEPENDENCIES) ./dependencies-$(TARGET)/
-	docker run -it $(DOCKER_DEPENDENCIES) export-assets $(DEPENDENCIES)
-	docker cp `docker ps -lq`:/tmp/dependencies.tar $(PWD)/
-	mv dependencies.tar dependencies-$(TARGET).tar
-	(cd ../scw-boot-tools; tar -uf ../Linux/dependencies-$(TARGET).tar usr/bin/scw-update-server-state)
-	docker rm `docker ps -lq`
-	rm -f dependencies-$(TARGET).tar.gz
-	@ls -lah dependencies-$(TARGET).tar
-	gzip dependencies-$(TARGET).tar
-	@ls -lah dependencies-$(TARGET).tar.gz
-
-
-dependencies-$(TARGET).tar.gz-dist:
-	wget -O dependencies-$(TARGET).tar.gz https://github.com/scaleway/initrd/blob/dist-Linux-$(TARGET)/Linux/dependencies-$(TARGET).tar.gz?raw=true
 
 
 minirootfs:

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -247,11 +247,10 @@ dependencies-$(TARGET).tar.gz:	dependencies-$(TARGET)/Dockerfile
 	test $(HOST_ARCH) = $(TARGET) || docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 	docker build -q -t $(DOCKER_DEPENDENCIES) ./dependencies-$(TARGET)/
-	docker run -it $(DOCKER_DEPENDENCIES) export-assets $(DEPENDENCIES)
-	docker cp `docker ps -lq`:/tmp/dependencies.tar $(PWD)/
+	rm -f dependencies.tar
+	docker run -it --rm -v $(PWD):/host $(DOCKER_DEPENDENCIES) export-assets $(DEPENDENCIES)
 	mv dependencies.tar dependencies-$(TARGET).tar
 	(cd ../scw-boot-tools; tar -uf ../Linux/dependencies-$(TARGET).tar usr/bin/scw-update-server-state)
-	docker rm `docker ps -lq`
 	rm -f dependencies-$(TARGET).tar.gz
 	@ls -lah dependencies-$(TARGET).tar
 	gzip dependencies-$(TARGET).tar

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -171,7 +171,7 @@ uInitrd-local:	initrd-Linux-$(TARGET).gz
 uInitrd-docker:	initrd-Linux-$(TARGET).gz
 	docker run \
 		-it --rm \
-		-v $(PWD):/host \
+		-v $(shell pwd):/host \
 		-w /tmp \
 		moul/u-boot-tools \
 		/bin/bash -xec \
@@ -189,7 +189,7 @@ uInitrd-shell: output-$(TARGET)/.deps
 	test $(HOST_ARCH) = $(TARGET)
 	docker run \
 		-it --rm \
-		-v $(PWD)/output-$(TARGET):/chroot \
+		-v $(shell pwd)/output-$(TARGET):/chroot \
 		-w /tmp \
 		armbuild/busybox \
 		chroot /chroot /bin/sh
@@ -203,7 +203,7 @@ initrd.gz:	initrd-Linux-$(TARGET).gz
 
 
 initrd-Linux-$(TARGET).gz:	output-$(TARGET)/.clean
-	cd output-$(TARGET) && find . -print0 | cpio --null -o --format=newc | gzip -9 > $(PWD)/$@
+	cd output-$(TARGET) && find . -print0 | cpio --null -o --format=newc | gzip -9 > $(shell pwd)/$@
 
 
 output-$(TARGET)/.deps:	dependencies-$(TARGET).tar.gz tree-$(TARGET)/usr/sbin/xnbd-client tree-$(TARGET) tree-$(TARGET)/usr/bin/oc-metadata Makefile $(shell find tree-$(TARGET) -type f) $(shell find tree-common -type f)
@@ -248,7 +248,7 @@ dependencies-$(TARGET).tar.gz:	dependencies-$(TARGET)/Dockerfile
 
 	docker build -q -t $(DOCKER_DEPENDENCIES) ./dependencies-$(TARGET)/
 	rm -f dependencies.tar
-	docker run -it --rm -v $(PWD):/host $(DOCKER_DEPENDENCIES) export-assets $(DEPENDENCIES)
+	docker run -it --rm -v $(shell pwd):/host $(DOCKER_DEPENDENCIES) export-assets $(DEPENDENCIES)
 	mv dependencies.tar dependencies-$(TARGET).tar
 	(cd ../scw-boot-tools; tar -uf ../Linux/dependencies-$(TARGET).tar usr/bin/scw-update-server-state)
 	rm -f dependencies-$(TARGET).tar.gz

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -14,6 +14,7 @@ DEPENDENCIES ?=	\
 	/lib/x86_64-linux-gnu/libresolv.so.2 \
 	/sbin/mkfs.ext4 \
 	/sbin/mkfs.btrfs \
+	/bin/mkfs.btrfs \
 	/sbin/parted \
 	/usr/bin/dropbearkey \
 	/usr/lib/klibc/bin/ipconfig \

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -3,23 +3,6 @@ STORE_HOSTNAME ?=	store.scw.42.am
 STORE_TARGET ?=		$(STORE_HOSTNAME):store/initrds/
 KERNEL_URL ?=		http://ports.ubuntu.com/ubuntu-ports/dists/lucid/main/installer-armel/current/images/versatile/netboot/vmlinuz
 MKIMAGE_OPTS ?=		-A arm -O linux -T ramdisk -C none -a 0 -e 0 -n initramfs
-DEPENDENCIES ?=	\
-	/bin/busybox \
-	/lib/arm-linux-gnueabihf/libnss_dns.so.2 \
-	/lib/arm-linux-gnueabihf/libnss_files.so.2 \
-	/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 \
-	/lib/x86_64-linux-gnu/libc.so.6 \
-	/lib/x86_64-linux-gnu/libnss_dns.so.2 \
-	/lib/x86_64-linux-gnu/libnss_files.so.2 \
-	/lib/x86_64-linux-gnu/libresolv.so.2 \
-	/sbin/mkfs.ext4 \
-	/sbin/mkfs.btrfs \
-	/bin/mkfs.btrfs \
-	/sbin/parted \
-	/usr/bin/dropbearkey \
-	/usr/lib/klibc/bin/ipconfig \
-	/usr/sbin/dropbear \
-	/usr/sbin/ntpdate
 DOCKER_DEPENDENCIES ?=	armbuild/initrd-dependencies
 CMDLINE ?=		ip=dhcp root=/dev/nbd0 nbd.max_parts=8 boot=local nousb noplymouth
 QEMU_OPTIONS ?=		-M versatilepb -cpu cortex-a9 -m 256 -no-reboot
@@ -138,7 +121,7 @@ dist:
 dist_do:
 	-git branch -D dist-Linux-$(TARGET) || true
 	git checkout -b dist-Linux-$(TARGET)
-	-$(MAKE) dependencies-$(TARGET).tar.gz && git add -f dependencies-$(TARGET).tar.gz
+	-$(MAKE) dependencies-$(TARGET).tar && git add -f dependencies-$(TARGET).tar
 	-$(MAKE) uInitrd-Linux-$(TARGET) && git add -f uInitrd-Linux-$(TARGET) initrd-Linux-$(TARGET).gz output-$(TARGET)
 	git commit -am ":ship: dist"
 	git push -u $(GIT_REMOTE) dist-Linux-$(TARGET) -f
@@ -195,10 +178,6 @@ uInitrd-shell: output-$(TARGET)/.deps
 		chroot /chroot /bin/sh
 
 
-output-$(TARGET)/usr/bin/oc-metadata:
-	mkdir -p $(shell dirname $@)
-
-
 initrd.gz:	initrd-Linux-$(TARGET).gz
 
 
@@ -206,10 +185,10 @@ initrd-Linux-$(TARGET).gz:	output-$(TARGET)/.clean
 	cd output-$(TARGET) && find . -print0 | cpio --null -o --format=newc | gzip -9 > $(shell pwd)/$@
 
 
-output-$(TARGET)/.deps:	dependencies-$(TARGET).tar.gz tree-$(TARGET)/usr/sbin/xnbd-client tree-$(TARGET) tree-$(TARGET)/usr/bin/oc-metadata Makefile $(shell find tree-$(TARGET) -type f) $(shell find tree-common -type f)
+output-$(TARGET)/.deps:	dependencies-$(TARGET).tar tree-$(TARGET) Makefile $(shell find tree-$(TARGET) -type f) $(shell find tree-common -type f)
 	rm -rf output-$(TARGET)
 	mkdir -p output-$(TARGET)
-	tar -m -C output-$(TARGET)/ -xzf dependencies-$(TARGET).tar.gz
+	tar -m -C output-$(TARGET)/ -xf dependencies-$(TARGET).tar
 	rsync -az tree-common/ output-$(TARGET)
 	rsync -az tree-$(TARGET)/ output-$(TARGET)
 	touch $@
@@ -227,38 +206,14 @@ tree-$(TARGET):
 	mkdir -p $@
 
 
-tree-$(TARGET)/usr/bin/oc-metadata:
-	mkdir -p tree-$(TARGET)/usr/bin
-	wget https://raw.githubusercontent.com/scaleway/image-tools/master/skeleton-common/usr/local/bin/oc-metadata -O $@
-	chmod +x $@
+dependencies.tar:	dependencies-$(TARGET).tar
 
 
-tree-$(TARGET)/usr/sbin/xnbd-client:
-	mkdir -p tree-$(TARGET)/usr/sbin
-	wget https://github.com/aimxhaisse/xnbd-client-static/raw/dist/bin/xnbd-client-static -O $@
-	chmod +x $@
-	ln -sf xnbd-client tree-$(TARGET)/usr/sbin/@xnbd-client
-
-
-dependencies.tar.gz:	dependencies-$(TARGET).tar.gz
-
-
-dependencies-$(TARGET).tar.gz:	dependencies-$(TARGET)/Dockerfile ../scw-boot-tools/$(TARGET)/usr/bin/scw-update-server-state
+dependencies-$(TARGET).tar:	dependencies-$(TARGET)/Dockerfile dependencies-$(TARGET)/tmp/scw-update-server-state
 	test $(HOST_ARCH) = $(TARGET) || docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
-	docker build -q -t $(DOCKER_DEPENDENCIES) ./dependencies-$(TARGET)/
-	rm -f dependencies.tar
-	docker run -it --rm -v $(shell pwd):/host $(DOCKER_DEPENDENCIES) export-assets $(DEPENDENCIES)
-	mv dependencies.tar dependencies-$(TARGET).tar
-	(cd ../scw-boot-tools/$(TARGET); tar -uf ../../Linux/dependencies-$(TARGET).tar usr/bin/scw-update-server-state)
-	rm -f dependencies-$(TARGET).tar.gz
-	@ls -lah dependencies-$(TARGET).tar
-	gzip dependencies-$(TARGET).tar
-	@ls -lah dependencies-$(TARGET).tar.gz
-
-	tar tvzf $@ | grep bin/busybox || rm -f $@
-	@test -f $@ || echo $@ is broken
-	@test -f $@ || exit 1
+	docker build -t $(DOCKER_DEPENDENCIES) ./dependencies-$(TARGET)/
+	docker run --rm $(DOCKER_DEPENDENCIES) > $@
 
 
 dependencies-shell:
@@ -267,11 +222,12 @@ dependencies-shell:
 	docker run -it $(DOCKER_DEPENDENCIES) /bin/bash
 
 
-../scw-boot-tools/$(TARGET)/usr/bin/scw-update-server-state: ../scw-boot-tools/scw-update-server-state.c
+dependencies-$(TARGET)/tmp/scw-update-server-state: ../scw-boot-tools/scw-update-server-state.c
 	make -C ../scw-boot-tools TARGET=$(TARGET)
 	mkdir -p ../scw-boot-tools/$(TARGET)/usr/bin
-	cp ../scw-boot-tools/$(TARGET)-scw-update-server-state ../scw-boot-tools/$(TARGET)/usr/bin/scw-update-server-state
-	chmod +x ../scw-boot-tools/$(TARGET)/usr/bin/scw-update-server-state
+	mkdir -p $(shell dirname $@)
+	cp ../scw-boot-tools/$(TARGET)-scw-update-server-state $@
+	chmod +x $@
 
 
 minirootfs:
@@ -305,7 +261,7 @@ minirootfs.tar:	minirootfs
 
 
 clean:
-	rm -rf output-$(TARGET) dependencies-$(TARGET).tar.gz initrd-Linux-$(TARGET).gz uInitrd-Linux-$(TARGET)
+	rm -rf output-$(TARGET) dependencies-$(TARGET).tar initrd-Linux-$(TARGET).gz uInitrd-Linux-$(TARGET)
 
 
 re: clean all

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -243,14 +243,14 @@ tree-$(TARGET)/usr/sbin/xnbd-client:
 dependencies.tar.gz:	dependencies-$(TARGET).tar.gz
 
 
-dependencies-$(TARGET).tar.gz:	dependencies-$(TARGET)/Dockerfile
+dependencies-$(TARGET).tar.gz:	dependencies-$(TARGET)/Dockerfile ../scw-boot-tools/$(TARGET)/usr/bin/scw-update-server-state
 	test $(HOST_ARCH) = $(TARGET) || docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 	docker build -q -t $(DOCKER_DEPENDENCIES) ./dependencies-$(TARGET)/
 	rm -f dependencies.tar
 	docker run -it --rm -v $(shell pwd):/host $(DOCKER_DEPENDENCIES) export-assets $(DEPENDENCIES)
 	mv dependencies.tar dependencies-$(TARGET).tar
-	(cd ../scw-boot-tools; tar -uf ../Linux/dependencies-$(TARGET).tar usr/bin/scw-update-server-state)
+	(cd ../scw-boot-tools/$(TARGET); tar -uf ../../Linux/dependencies-$(TARGET).tar usr/bin/scw-update-server-state)
 	rm -f dependencies-$(TARGET).tar.gz
 	@ls -lah dependencies-$(TARGET).tar
 	gzip dependencies-$(TARGET).tar
@@ -267,11 +267,11 @@ dependencies-shell:
 	docker run -it $(DOCKER_DEPENDENCIES) /bin/bash
 
 
-../scw-boot-tools/usr/bin/scw-update-server-state: ../scw-boot-tools/scw-update-server-state.c
-	make -C ../scw-boot-tools
-	mkdir -p ../scw-boot-tools/usr/bin
-	cp ../scw-boot-tools/scw-update-server-state ../scw-boot-tools/usr/bin/
-	chmod +x ../scw-boot-tools/usr/bin/scw-update-server-state
+../scw-boot-tools/$(TARGET)/usr/bin/scw-update-server-state: ../scw-boot-tools/scw-update-server-state.c
+	make -C ../scw-boot-tools TARGET=$(TARGET)
+	mkdir -p ../scw-boot-tools/$(TARGET)/usr/bin
+	cp ../scw-boot-tools/$(TARGET)-scw-update-server-state ../scw-boot-tools/$(TARGET)/usr/bin/scw-update-server-state
+	chmod +x ../scw-boot-tools/$(TARGET)/usr/bin/scw-update-server-state
 
 
 minirootfs:

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -53,7 +53,11 @@ travis_check:
 	bash -n tree-common/init tree-common/shutdown tree-common/functions tree-common/boot-*
 
 
-travis_build: uInitrd
+travis_build:
+	$(MAKE) TARGET=x86_64
+
+	#$(MAKE) TARGET=armv7l
+	# due to the lack of binfmt-support in travis, armv7l is currently disabled
 
 
 qemu:

--- a/Linux/README.md
+++ b/Linux/README.md
@@ -133,7 +133,10 @@ Here are the availble *initrd variables*:
 
 ### master (unreleased)
 
-* Improve multiarch and cross-build support
+* Complete multiarch refactor [#124](https://github.com/scaleway/initrd/pull/124)
+* Complete dependencies refactor, huge speed gain
+* Travis builds fixed
+* Bump dependencies to the latest version (taking binaries from `ubuntu:wily` instead of `ubuntu:vivid`)
 * Initial BTRFS support [#123](https://github.com/scaleway/initrd/pull/123) ([@boris-arzur](https://github.com/boris-arzur))
 
 ### v3.6 (2015-11-24)

--- a/Linux/README.md
+++ b/Linux/README.md
@@ -133,6 +133,7 @@ Here are the availble *initrd variables*:
 
 ### master (unreleased)
 
+* Improve multiarch and cross-build support
 * Initial BTRFS support [#123](https://github.com/scaleway/initrd/pull/123) ([@boris-arzur](https://github.com/boris-arzur))
 
 ### v3.6 (2015-11-24)

--- a/Linux/dependencies-armv7l/Dockerfile
+++ b/Linux/dependencies-armv7l/Dockerfile
@@ -3,27 +3,76 @@ FROM scaleway/ubuntu:armhf-wily
 RUN /usr/local/sbin/builder-enter
 
 # Install dependencies
-RUN apt-get update \
- && apt-get upgrade -y \
- && apt-get install -y \
-   curl \
-   dropbear \
-   nfs-common \
-   ntpdate \
-   parted \
-   btrfs-tools \
-   udhcpc \
-   wget \
+RUN apt-get update          \
+ && apt-get upgrade -y      \
+ && apt-get install -y      \
+   curl                     \
+   dropbear                 \
+   nfs-common               \
+   ntpdate                  \
+   parted                   \
+   btrfs-tools              \
+   udhcpc                   \
+   wget                     \
  && apt-get clean
 
 
 # Install busybox-static
-RUN wget http://ftp.fr.debian.org/debian/pool/main/b/busybox/busybox-static_1.22.0-9+deb8u1_armhf.deb -O /tmp/busybox.deb \
- && dpkg -i /tmp/busybox.deb \
+RUN wget -O /tmp/busybox.deb                                                                        \
+      http://ftp.fr.debian.org/debian/pool/main/b/busybox/busybox-static_1.22.0-9+deb8u1_armhf.deb  \
+ && dpkg -i /tmp/busybox.deb                                                                        \
  && rm -f /tmp/busybox.deb
 
 
-# Install export scripts
-RUN wget https://raw.githubusercontent.com/moul/mbin/master/ldd-rec.pl -O /usr/local/bin/ldd-rec.pl \
+# Fetch ldd-rec.pl
+RUN wget https://raw.githubusercontent.com/moul/mbin/master/ldd-rec.pl  \
+      -O /usr/local/bin/ldd-rec.pl                                      \
  && chmod +x /usr/local/bin/ldd-rec.pl
+
+
+# Fetch oc-metadata
+ENV IMAGE_TOOLS_REV=5aa5c8e18e4c53aed84b6212439ab9158e570d55
+RUN wget -O /usr/bin/oc-metadata                                                                                           \
+      https://raw.githubusercontent.com/scaleway/image-tools/${IMAGE_TOOLS_REV}/skeleton-common/usr/local/bin/oc-metadata  \
+ && chmod +x /usr/bin/oc-metadata
+
+
+# Fetch static xnbd-client
+RUN mkdir -p /usr/sbin                                                                  \
+ && wget -O /usr/sbin/xnbd-client                                                       \
+      https://github.com/aimxhaisse/xnbd-client-static/raw/dist/bin/xnbd-client-static  \
+ && chmod +x /usr/sbin/xnbd-client                                                      \
+ && ln -s xnbd-client /usr/sbin/@xnbd-client
+
+
+# Image metadata
+CMD ["cat", "/dependencies.tar"]
+
+
+# Copy local assets
+COPY ./tmp/scw-update-server-state /usr/bin/scw-update-server-state
 COPY ./export-assets /usr/local/bin/
+
+
+# Generate tarball
+RUN export-assets \
+      /bin/busybox \
+      /bin/mkfs.btrfs \
+      /lib/arm-linux-gnueabihf/libnss_dns.so.2 \
+      /lib/arm-linux-gnueabihf/libnss_files.so.2 \
+      /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 \
+      /lib/x86_64-linux-gnu/libc.so.6 \
+      /lib/x86_64-linux-gnu/libnss_dns.so.2 \
+      /lib/x86_64-linux-gnu/libnss_files.so.2 \
+      /lib/x86_64-linux-gnu/libresolv.so.2 \
+      /sbin/mkfs.btrfs \
+      /sbin/mkfs.ext4 \
+      /sbin/parted \
+      /usr/bin/dropbearkey \
+      /usr/bin/oc-metadata \
+      /usr/lib/klibc/bin/ipconfig \
+      /usr/sbin/@xnbd-client \
+      /usr/sbin/dropbear \
+      /usr/sbin/ntpdate \
+      /usr/sbin/xnbd-client \
+      /usr/bin/scw-update-server-state

--- a/Linux/dependencies-armv7l/Dockerfile
+++ b/Linux/dependencies-armv7l/Dockerfile
@@ -38,10 +38,10 @@ RUN wget -O /usr/bin/oc-metadata                                                
 
 
 # Fetch static xnbd-client
-RUN mkdir -p /usr/sbin                                                                  \
- && wget -O /usr/sbin/xnbd-client                                                       \
-      https://github.com/aimxhaisse/xnbd-client-static/raw/dist/bin/xnbd-client-static  \
- && chmod +x /usr/sbin/xnbd-client                                                      \
+RUN mkdir -p /usr/sbin                                                                                                 \
+ && wget -O /usr/sbin/xnbd-client                                                                                      \
+      https://github.com/multiarch/build-xnbd-client-static/releases/download/v1.0/armv7l-xnbd-client-static-stripped  \
+ && chmod +x /usr/sbin/xnbd-client                                                                                     \
  && ln -s xnbd-client /usr/sbin/@xnbd-client
 
 

--- a/Linux/dependencies-armv7l/Dockerfile
+++ b/Linux/dependencies-armv7l/Dockerfile
@@ -1,5 +1,6 @@
-FROM armbuild/ubuntu:vivid
+FROM scaleway/ubuntu:armhf-wily
 
+RUN /usr/local/sbin/builder-enter
 
 # Install dependencies
 RUN apt-get update \

--- a/Linux/dependencies-armv7l/export-assets
+++ b/Linux/dependencies-armv7l/export-assets
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-EXPORT=/host/dependencies.tar
+EXPORT=/dependencies.tar
 
 cd /
 tar -cf ${EXPORT} dev/null
@@ -23,3 +23,4 @@ for bin in $@; do
 done
 tar --delete -f ${EXPORT} dev/null
 tar -tvf ${EXPORT}
+tar tvf /dependencies.tar | grep -q bin/busybox || (echo "Invalid tarball, no busybox found, exiting."; exit 1)

--- a/Linux/dependencies-armv7l/export-assets
+++ b/Linux/dependencies-armv7l/export-assets
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-EXPORT=/tmp/dependencies.tar
+EXPORT=/host/dependencies.tar
 
 cd /
 tar -cf ${EXPORT} dev/null

--- a/Linux/dependencies-armv7l/export-assets
+++ b/Linux/dependencies-armv7l/export-assets
@@ -5,7 +5,18 @@ EXPORT=/tmp/dependencies.tar
 cd /
 tar -cf ${EXPORT} dev/null
 for bin in $@; do
-    for file in $bin $(ldd-rec.pl $@); do
+    if [ ! -f $bin ]; then
+	continue
+    fi
+    echo "Exporting '$file' and dependencies."
+
+    for file in $bin $(ldd-rec.pl $bin); do
+	if [ ! -f $file ]; then
+	    continue
+	fi
+
+	echo "$file"
+	    
 	tar -uf ${EXPORT} $(echo $file | sed -e 's/^\///')
 	tar -uf ${EXPORT} $(readlink -f $file | sed -e 's/^\///')
     done

--- a/Linux/dependencies-x86_64/Dockerfile
+++ b/Linux/dependencies-x86_64/Dockerfile
@@ -3,27 +3,76 @@ FROM scaleway/ubuntu:amd64-wily
 RUN /usr/local/sbin/builder-enter
 
 # Install dependencies
-RUN apt-get update \
- && apt-get upgrade -y \
- && apt-get install -y \
-   curl \
-   dropbear \
-   nfs-common \
-   ntpdate \
-   parted \
-   btrfs-tools \
-   udhcpc \
-   wget \
+RUN apt-get update          \
+ && apt-get upgrade -y      \
+ && apt-get install -y      \
+   curl                     \
+   dropbear                 \
+   nfs-common               \
+   ntpdate                  \
+   parted                   \
+   btrfs-tools              \
+   udhcpc                   \
+   wget                     \
  && apt-get clean
 
 
 # Install busybox-static
-RUN wget http://ftp.fr.debian.org/debian/pool/main/b/busybox/busybox-static_1.22.0-9+deb8u1_amd64.deb -O /tmp/busybox.deb \
- && dpkg -i /tmp/busybox.deb \
+RUN wget -O /tmp/busybox.deb                                                                        \
+      http://ftp.fr.debian.org/debian/pool/main/b/busybox/busybox-static_1.22.0-9+deb8u1_amd64.deb  \
+ && dpkg -i /tmp/busybox.deb                                                                        \
  && rm -f /tmp/busybox.deb
 
 
-# Install export scripts
-RUN wget https://raw.githubusercontent.com/moul/mbin/master/ldd-rec.pl -O /usr/local/bin/ldd-rec.pl \
+# Fetch ldd-rec.pl
+RUN wget https://raw.githubusercontent.com/moul/mbin/master/ldd-rec.pl  \
+      -O /usr/local/bin/ldd-rec.pl                                      \
  && chmod +x /usr/local/bin/ldd-rec.pl
+
+
+# Fetch oc-metadata
+ENV IMAGE_TOOLS_REV=5aa5c8e18e4c53aed84b6212439ab9158e570d55
+RUN wget -O /usr/bin/oc-metadata                                                                                           \
+      https://raw.githubusercontent.com/scaleway/image-tools/${IMAGE_TOOLS_REV}/skeleton-common/usr/local/bin/oc-metadata  \
+ && chmod +x /usr/bin/oc-metadata
+
+
+# Fetch static xnbd-client
+RUN mkdir -p /usr/sbin                                                                  \
+ && wget -O /usr/sbin/xnbd-client                                                       \
+      https://github.com/aimxhaisse/xnbd-client-static/raw/dist/bin/xnbd-client-static  \
+ && chmod +x /usr/sbin/xnbd-client                                                      \
+ && ln -s xnbd-client /usr/sbin/@xnbd-client
+
+
+# Image metadata
+CMD ["cat", "/dependencies.tar"]
+
+
+# Copy local assets
+COPY ./tmp/scw-update-server-state /usr/bin/scw-update-server-state
 COPY ./export-assets /usr/local/bin/
+
+
+# Generate tarball
+RUN export-assets \
+      /bin/busybox \
+      /bin/mkfs.btrfs \
+      /lib/arm-linux-gnueabihf/libnss_dns.so.2 \
+      /lib/arm-linux-gnueabihf/libnss_files.so.2 \
+      /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 \
+      /lib/x86_64-linux-gnu/libc.so.6 \
+      /lib/x86_64-linux-gnu/libnss_dns.so.2 \
+      /lib/x86_64-linux-gnu/libnss_files.so.2 \
+      /lib/x86_64-linux-gnu/libresolv.so.2 \
+      /sbin/mkfs.btrfs \
+      /sbin/mkfs.ext4 \
+      /sbin/parted \
+      /usr/bin/dropbearkey \
+      /usr/bin/oc-metadata \
+      /usr/lib/klibc/bin/ipconfig \
+      /usr/sbin/@xnbd-client \
+      /usr/sbin/dropbear \
+      /usr/sbin/ntpdate \
+      /usr/sbin/xnbd-client \
+      /usr/bin/scw-update-server-state

--- a/Linux/dependencies-x86_64/Dockerfile
+++ b/Linux/dependencies-x86_64/Dockerfile
@@ -38,10 +38,10 @@ RUN wget -O /usr/bin/oc-metadata                                                
 
 
 # Fetch static xnbd-client
-RUN mkdir -p /usr/sbin                                                                  \
- && wget -O /usr/sbin/xnbd-client                                                       \
-      https://github.com/aimxhaisse/xnbd-client-static/raw/dist/bin/xnbd-client-static  \
- && chmod +x /usr/sbin/xnbd-client                                                      \
+RUN mkdir -p /usr/sbin                                                                                                 \
+ && wget -O /usr/sbin/xnbd-client                                                                                      \
+      https://github.com/multiarch/build-xnbd-client-static/releases/download/v1.0/x86_64-xnbd-client-static-stripped  \
+ && chmod +x /usr/sbin/xnbd-client                                                                                     \
  && ln -s xnbd-client /usr/sbin/@xnbd-client
 
 

--- a/Linux/dependencies-x86_64/Dockerfile
+++ b/Linux/dependencies-x86_64/Dockerfile
@@ -1,5 +1,6 @@
-FROM ubuntu:vivid
+FROM scaleway/ubuntu:amd64-wily
 
+RUN /usr/local/sbin/builder-enter
 
 # Install dependencies
 RUN apt-get update \
@@ -10,6 +11,7 @@ RUN apt-get update \
    nfs-common \
    ntpdate \
    parted \
+   btrfs-tools \
    udhcpc \
    wget \
  && apt-get clean

--- a/Linux/dependencies-x86_64/export-assets
+++ b/Linux/dependencies-x86_64/export-assets
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-EXPORT=/host/dependencies.tar
+EXPORT=/dependencies.tar
 
 cd /
 tar -cf ${EXPORT} dev/null
@@ -23,3 +23,4 @@ for bin in $@; do
 done
 tar --delete -f ${EXPORT} dev/null
 tar -tvf ${EXPORT}
+tar tvf /dependencies.tar | grep -q bin/busybox || (echo "Invalid tarball, no busybox found, exiting."; exit 1)

--- a/Linux/dependencies-x86_64/export-assets
+++ b/Linux/dependencies-x86_64/export-assets
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-EXPORT=/tmp/dependencies.tar
+EXPORT=/host/dependencies.tar
 
 cd /
 tar -cf ${EXPORT} dev/null

--- a/Linux/dependencies-x86_64/export-assets
+++ b/Linux/dependencies-x86_64/export-assets
@@ -5,7 +5,18 @@ EXPORT=/tmp/dependencies.tar
 cd /
 tar -cf ${EXPORT} dev/null
 for bin in $@; do
-    for file in $bin $(ldd-rec.pl $@); do
+    if [ ! -f $bin ]; then
+	continue
+    fi
+    echo "Exporting '$file' and dependencies."
+
+    for file in $bin $(ldd-rec.pl $bin); do
+	if [ ! -f $file ]; then
+	    continue
+	fi
+
+	echo "$file"
+	    
 	tar -uf ${EXPORT} $(echo $file | sed -e 's/^\///')
 	tar -uf ${EXPORT} $(readlink -f $file | sed -e 's/^\///')
     done

--- a/scw-boot-tools/.gitignore
+++ b/scw-boot-tools/.gitignore
@@ -1,1 +1,3 @@
+*-scw-update-server-state
 scw-update-server-state
+

--- a/scw-boot-tools/Dockerfile
+++ b/scw-boot-tools/Dockerfile
@@ -1,2 +1,0 @@
-FROM multiarch/crossbuild:latest
-COPY . /workdir

--- a/scw-boot-tools/Dockerfile
+++ b/scw-boot-tools/Dockerfile
@@ -1,5 +1,2 @@
-FROM gcc:4.9
-COPY . /app
-WORKDIR /app
-RUN make
-CMD ["cat", "./scw-update-server-state"]
+FROM multiarch/crossbuild:latest
+COPY . /workdir

--- a/scw-boot-tools/Makefile
+++ b/scw-boot-tools/Makefile
@@ -1,37 +1,51 @@
 NAME = scw-update-server-state
 LDFLAGS = -static -lm
+HOST_ARCH ?= $(shell uname -m)
+TARGET ?= armv7l
 
 all: build
 
 
-$(NAME): scw-update-server-state.c
-	cc $< -o $@ $(LDFLAGS)
+$(TARGET)-$(NAME): scw-update-server-state.c
+	if [ -n "$(CROSS_TRIPLE)" ]; then             \
+	  crossbuild cc $< -o $@ $(LDFLAGS);          \
+	  file $@ || true;                            \
+	else                                          \
+	  if [ "$(HOST_ARCH)" = "$(TARGET)" ]; then   \
+	    cc $< -o $@ $(LDFLAGS);                   \
+	    file $@ || true;                          \
+	  else                                        \
+	    $(MAKE) docker_build;                     \
+	  fi;                                         \
+	fi
 
 
 .PHONY: build
-build: $(NAME)
+build: $(TARGET)-$(NAME)
+
+
+.PHONY: local_build
+local_build: scw-update-server-state.c
 
 
 .PHONY: clean
 clean:
-	rm -f $(NAME)
+	rm -f *-$(NAME)
 
 
 .PHONY: re
 re: clean all
 
 
-.PHONY: travis_check travis_build
-travis_check travis_build: build_with_fallback
+.PHONY: travis_check
+travis_check:
+	@echo "travis_check: nothing to do."
 
 
-.PHONY: build_with_fallback
-build_with_fallback:
-	$(MAKE) build || $(MAKE) docker_build
+.PHONY: travis_build
+travis_build: build
 
 
 .PHONY: docker_build
 docker_build:
-	docker build -t $(NAME)-builder .
-	docker run --rm $(NAME)-builder > $(NAME)
-	chmod +x $(NAME)
+	docker run --rm -it -e TARGET=$(TARGET) -e CROSS_TRIPLE=$(TARGET) -v $(shell pwd):/workdir multiarch/crossbuild make


### PR DESCRIPTION
Before, we needed to build the dependencies.tar.gz from the same architecture, so I had a hack that wget a tarball of pre-build dependencies.tar.gz

Now, I register binfmt-support and use the new multiarch image that can be built from x86_64