### PR TITLE
Improve initial time set-up

### DIFF
--- a/Linux/tree-common/etc/udhcpc/default.script
+++ b/Linux/tree-common/etc/udhcpc/default.script
@@ -37,7 +37,7 @@ case $1 in
 nameserver $i"
         done
 
-	[ -n "$ntpsrv" ] && echo "$ntpsrv" > /etc/ntpsrv
+	[ -n "${ntpsrv}" ] && echo "${ntpsrv}" >> /etc/ntpsrv
 
 	[ -n "$hostname" ] && echo "$hostname" > /proc/sys/kernel/hostname
 

--- a/Linux/tree-common/init
+++ b/Linux/tree-common/init
@@ -183,9 +183,9 @@ signal_state kernel-started
 # Adjust time
 if [ "$(get_any NO_NTPDATE)" != "1" ]; then
     log_begin_msg "Adjusting time (ntp)"
-    NTPSRV=$(cat /etc/ntpsrv)
-    run ntpdate -d -b -p 2 "${NTPSRV}"
-    run ntpdate -d -b -p 6 "${NTPSRV}" &
+    # Clock is stepped after 3 NTP probes to each server, each query timeout in 1 second
+    # /etc/ntpsrv was improved with any NTP server(s) provided thru DHCP (see etc/udhcpc/default.script)
+    run ntpdate -b -p 3 -t 1 $(cat /etc/ntpsrv)
     log_end_msg
 fi
 


### PR DESCRIPTION
Removing NTP's debug/no-op switch
Enabling multi-servers support
DHCP reply don't replace NTP stored server(s) but adds to it