### PR TITLE
Add kexec arm

### DIFF
--- a/Linux/dependencies-arm64/Dockerfile
+++ b/Linux/dependencies-arm64/Dockerfile
@@ -66,6 +66,7 @@ RUN export-assets \
       /lib/x86_64-linux-gnu/libnss_dns.so.2 \
       /lib/x86_64-linux-gnu/libnss_files.so.2 \
       /lib/x86_64-linux-gnu/libresolv.so.2 \
+      /sbin/kexec \
       /sbin/mkfs.btrfs \
       /sbin/mkfs.ext4 \
       /sbin/parted \

--- a/Linux/dependencies-arm64/Dockerfile
+++ b/Linux/dependencies-arm64/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update          \
  && apt-get install -y      \
    curl                     \
    dropbear                 \
+   kexec-tools              \
    nfs-common               \
    ntpdate                  \
    parted                   \

--- a/Linux/dependencies-armv7l/Dockerfile
+++ b/Linux/dependencies-armv7l/Dockerfile
@@ -66,6 +66,7 @@ RUN export-assets \
       /lib/x86_64-linux-gnu/libnss_dns.so.2 \
       /lib/x86_64-linux-gnu/libnss_files.so.2 \
       /lib/x86_64-linux-gnu/libresolv.so.2 \
+      /sbin/kexec \
       /sbin/mkfs.btrfs \
       /sbin/mkfs.ext4 \
       /sbin/parted \

--- a/Linux/dependencies-armv7l/Dockerfile
+++ b/Linux/dependencies-armv7l/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update          \
  && apt-get install -y      \
    curl                     \
    dropbear                 \
+   kexec-tools              \
    nfs-common               \
    ntpdate                  \
    parted                   \


### PR DESCRIPTION
Add missing kexec to arm builds to hopefully enable KEXEC_KERNEL / KEXEC_INITRD support for arm.

Confirm builds on arm7l, arm64 untested.