### PR TITLE
Upgrade to Xenial

### DIFF
--- a/Linux/dependencies-arm64/Dockerfile
+++ b/Linux/dependencies-arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM scaleway/ubuntu:arm64-wily
+FROM scaleway/ubuntu:arm64-xenial
 
 RUN /usr/local/sbin/scw-builder-enter
 

--- a/Linux/dependencies-armv7l/Dockerfile
+++ b/Linux/dependencies-armv7l/Dockerfile
@@ -1,4 +1,4 @@
-FROM scaleway/ubuntu:armhf-wily
+FROM scaleway/ubuntu:armhf-xenial
 
 RUN /usr/local/sbin/scw-builder-enter
 

--- a/Linux/dependencies-x86_64/Dockerfile
+++ b/Linux/dependencies-x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM scaleway/ubuntu:amd64-wily
+FROM scaleway/ubuntu:amd64-xenial
 
 RUN /usr/local/sbin/scw-builder-enter
 


### PR DESCRIPTION
Maybe a good idea to pull dependencies from Xenial instead if the (unsupported?) Wily. 