### PR TITLE
Fix quoting in get_metadata to support spaces.

### DIFF
--- a/Linux/tree-common/functions
+++ b/Linux/tree-common/functions
@@ -152,8 +152,8 @@ has_opt() {
 get_metadata() {
     for idx in $(seq -w 0 $(scw-metadata --cached TAGS)); do
 	tag=$(scw-metadata --cached TAGS_$idx)
-	if [ $(echo "$tag" | grep "^$1=") ]; then
-	    echo $tag | sed 's/^[^=]*=//' | resolve_hostnames
+	if [ "$(echo "$tag" | grep "^$1=")" ]; then
+	    echo "$tag" | sed 's/^[^=]*=//' | resolve_hostnames
 	    return
 	fi
     done


### PR DESCRIPTION
Variables have to be quoted to avoid shell globbing, execution etc. - or just support spaces in e.g. taggings ( KEXEC_APPEND="root=/dev/vda my-very-special-kernel-cmdline" ).