### PR TITLE
Escape in Regexp

### DIFF
--- a/Linux/tree-common/functions
+++ b/Linux/tree-common/functions
@@ -129,7 +129,7 @@ signal_state() {
 ## Helpers
 
 resolve_hostnames() {
-    sed "s/metadata.local/${METADATA_IP}/g"
+    sed "s/metadata\.local/${METADATA_IP}/g"
 }
 
 


### PR DESCRIPTION
escape `.` in sed as it matches any char.